### PR TITLE
Increase kraken tracker pagination limit

### DIFF
--- a/src/hooks/useWalletLeaderboard.ts
+++ b/src/hooks/useWalletLeaderboard.ts
@@ -156,7 +156,7 @@ export const useWalletLeaderboard = (): UseWalletLeaderboardReturn => {
       
       let allWallets: WalletData[] = isLoadMore ? wallets : [];
       const baseUrl = "https://scan.w-chain.com/api/v2/addresses";
-      let url = `${baseUrl}?items_count=50`;
+      let url = `${baseUrl}?items_count=100`;
       let keepFetching = true;
 
       while (keepFetching) {
@@ -198,7 +198,7 @@ export const useWalletLeaderboard = (): UseWalletLeaderboardReturn => {
         // Check if more pages exist
         if (result.next_page_params) {
           const params = new URLSearchParams(result.next_page_params).toString();
-          url = `${baseUrl}?items_count=50&${params}`;
+          url = `${baseUrl}?items_count=100&${params}`;
         } else {
           keepFetching = false;
         }


### PR DESCRIPTION
Increase wallet leaderboard pagination size from 50 to 100 to improve loading times for the Kraken tracker.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f73bfad-602f-4095-a1cd-9f3e65b25f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f73bfad-602f-4095-a1cd-9f3e65b25f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

