### PR TITLE
Investigate kraken watchlist cross-origin policy error

### DIFF
--- a/src/components/TokenListItem.tsx
+++ b/src/components/TokenListItem.tsx
@@ -27,7 +27,7 @@ export const TokenListItem = ({ token }: TokenListItemProps) => {
   };
 
   const openScanner = () => {
-    window.open(`https://w-chain.com`, '_blank');
+    window.open(`https://w-chain.com`, '_blank', 'noopener,noreferrer');
   };
 
   const formatAddress = (address: string) => {

--- a/src/components/WalletInfo.tsx
+++ b/src/components/WalletInfo.tsx
@@ -29,7 +29,7 @@ export const WalletInfo = ({ walletInfo, onDisconnect }: WalletInfoProps) => {
   };
 
   const openWChainScan = () => {
-    window.open(`https://scan.w-chain.com/address/${walletInfo.address}`, '_blank');
+    window.open(`https://scan.w-chain.com/address/${walletInfo.address}`, '_blank', 'noopener,noreferrer');
   };
 
   const wcoUsdValue = wcoData && parseFloat(walletInfo.wcoBalance) > 0 


### PR DESCRIPTION
Update external link handling to resolve Cross-Origin-Opener-Policy navigation blocks.

Clicking links from the Kraken watchlist to the `w-chain.c` explorer results in a browser error (`navigation was blocked by: cross origin opener policy`). This occurs because the links are opened in a way that creates an opener relationship, which is then blocked by a strict `Cross-Origin-Opener-Policy: same-origin` header on the target or an intermediate redirector. Adding `rel="noopener noreferrer"` to `<a>` tags or using `window.open(url, '_blank', 'noopener')` will sever this relationship and prevent the block.

---
<a href="https://cursor.com/background-agent?bcId=bc-b030ff0c-754c-4ec6-9e74-87fc91bff722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b030ff0c-754c-4ec6-9e74-87fc91bff722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

